### PR TITLE
Added Secret support (RF 7.4+)

### DIFF
--- a/.github/workflows/python-package-regression.yml
+++ b/.github/workflows/python-package-regression.yml
@@ -17,6 +17,9 @@ jobs:
         robotframework-version: ["7.2"]
         include:
         - os: ubuntu-latest
+          python-version: "3.11"                
+          robotframework-version: "7.4b1"            
+        - os: ubuntu-latest
           python-version: "3.12"
           robotframework-version: "6.1.1"
         - os: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,6 +19,9 @@ jobs:
         robotframework-version: ["7.2"]
         include:
         - os: ubuntu-latest
+          python-version: "3.11"                
+          robotframework-version: "7.4b1"                            
+        - os: ubuntu-latest
           python-version: "3.12"
           robotframework-version: "6.1.1"
         - os: ubuntu-latest

--- a/CHANGELOG_SECRET_SUPPORT.md
+++ b/CHANGELOG_SECRET_SUPPORT.md
@@ -1,0 +1,83 @@
+# KeePassLibrary Secret Type Support
+
+## New Feature: Robot Framework 7.4+ Secret Type Support
+
+### Overview
+KeePassLibrary now supports Robot Framework's Secret type for password handling when using Robot Framework 7.4 or later. This enhancement provides better security by utilizing RF's built-in secret value handling.
+
+### Changes Made
+
+#### Enhanced `get_entry_password` Keyword
+- **New Parameter**: `as_secret` (boolean, default: `False`)
+- **Backward Compatibility**: Default behavior unchanged - returns plain text password
+- **Secret Support**: When `as_secret=True` and RF 7.4+, returns `robot.api.types.Secret`
+- **Version Validation**: Fails gracefully with clear error message if `as_secret=True` but RF < 7.4
+
+#### Implementation Details
+1. **Import Safety**: Graceful handling when `robot.api.types.Secret` is not available
+2. **Version Detection**: Automatic Robot Framework version checking
+3. **Error Handling**: New `RobotFrameworkVersionError` exception for version conflicts
+4. **Documentation**: Updated keyword documentation with examples
+
+### Usage Examples
+
+#### Traditional Usage (Unchanged)
+```robotframework
+${entry} =     Get Entries By Title    my_entry    first=True
+${password} =  Get Entry Password      ${entry}
+# Returns: plain text password string
+```
+
+#### New Secret Type Usage (RF 7.4+)
+
+```robotframework
+${entry} =     Get Entries By Title    my_entry    first=True  
+${secret} =    Get Entry Password      ${entry}    as_secret=True
+# Returns: robot.api.types.Secret object
+```
+
+#### Explicit Traditional Usage
+
+```robotframework
+${entry} =     Get Entries By Title    my_entry    first=True
+${password} =  Get Entry Password      ${entry}    as_secret=False  
+# Returns: plain text password string (explicit)
+```
+
+### Version Compatibility
+
+- **Robot Framework < 7.4**: Only `as_secret=False` supported
+- **Robot Framework 7.4+**: Both `as_secret=False` and `as_secret=True` supported
+- **Automatic Detection**: Library automatically detects RF version capabilities
+
+### Error Handling
+
+When `as_secret=True` is used with Robot Framework < 7.4:
+
+```
+RobotFrameworkVersionError: Secret type is not available in Robot Framework 6.1.1. Secret type requires Robot Framework 7.4 or later.
+```
+
+### Testing
+
+- **Unit Tests**: Comprehensive version checking and functionality tests
+- **Robot Tests**: Integration tests for both modes and error conditions
+- **Backward Compatibility**: Verified existing tests continue to pass
+
+### Files Modified
+- `src/KeePassLibrary/keywords/keepassentry.py`: Enhanced get_entry_password implementation
+- `src/KeePassLibrary/errors.py`: Added RobotFrameworkVersionError exception
+- `atests/Entry.robot`: Added comprehensive test cases for Secret functionality
+- `utests/test/test_secret_functionality.py`: New unit test suite
+
+### Benefits
+1. **Enhanced Security**: Leverages Robot Framework's Secret type for sensitive data
+2. **Backward Compatibility**: Existing code works without changes
+3. **Future Ready**: Prepared for Robot Framework's evolving security features
+4. **Clear Error Messages**: Helpful guidance for version compatibility issues
+
+### Migration Path
+No migration required! Existing code continues to work unchanged. To use Secret types:
+1. Upgrade to Robot Framework 7.4+
+2. Add `as_secret=True` parameter where needed
+3. Handle Secret objects in your test logic as appropriate

--- a/atests/Entry.robot
+++ b/atests/Entry.robot
@@ -505,3 +505,48 @@ Attachment Should Not Be Present Fail
     Set Entry Attachment               ${entry}    spam.txt      ${binary_set}
     ${error_msg}=                  Set Variable     The entry should not contain attachment 'spam.txt', but it does.
     Run Keyword And Expect Error   ${error_msg}     Entry Should Not Contain Attachment    ${entry}    spam.txt
+
+Get Entry Password As Secret - Robot Framework 7.4+
+    [Documentation]    Get entry password as Secret type when supported
+    [Tags]    get    secret    password
+    ${entry_title}=    Set Variable    root_entry
+    ${value_expected}=    Set Variable    passw0rd
+    ${entry}=    Get Entries By Title    ${entry_title}    first=True
+    
+    # Test with as_secret=False (default behavior)
+    ${value_plain}=    Get Entry Password    ${entry}
+    Should Be Equal As Strings    ${value_expected}    ${value_plain}
+    
+    # Try to get password as Secret - will work if RF 7.4+ or fail with appropriate error
+    ${rf_version}=    Evaluate    robot.__version__    modules=robot
+    ${version_parts}=    Split String    ${rf_version}    .
+    ${major}=    Convert To Integer    ${version_parts}[0]
+    ${minor_str}=    Fetch From Left    ${version_parts}[1]    b
+    ${minor}=    Convert To Integer    ${minor_str}
+    
+    IF    ${major} > 7 or (${major} == 7 and ${minor} >= 4)
+        # Robot Framework 7.4+ - Secret should work
+        ${value_secret}=    Get Entry Password    ${entry}    as_secret=True
+        # Secret type should contain the same password value
+        ${secret_value}=    Evaluate    str($value_secret)
+        Should Contain    ${secret_value}    Secret
+    ELSE
+        # Robot Framework < 7.4 - Should fail with appropriate error
+        ${error_msg}=    Set Variable    Secret type is not available in Robot Framework ${rf_version}. Secret type requires Robot Framework 7.4 or later.
+        Run Keyword And Expect Error    *Secret type*Robot Framework*7.4*    Get Entry Password    ${entry}    as_secret=True
+    END
+
+Get Entry Password As Secret - Default Behavior
+    [Documentation]    Verify default behavior remains unchanged
+    [Tags]    get    password    backward_compatibility
+    ${entry_title}=    Set Variable    root_entry
+    ${value_expected}=    Set Variable    passw0rd
+    ${entry}=    Get Entries By Title    ${entry_title}    first=True
+    
+    # Default behavior should return plain password
+    ${value}=    Get Entry Password    ${entry}
+    Should Be Equal As Strings    ${value_expected}    ${value}
+    
+    # Explicitly set as_secret=False should work the same way
+    ${value_explicit}=    Get Entry Password    ${entry}    as_secret=False
+    Should Be Equal As Strings    ${value_expected}    ${value_explicit}

--- a/src/KeePassLibrary/errors.py
+++ b/src/KeePassLibrary/errors.py
@@ -36,3 +36,7 @@ class DateTimeInvalid(KeepassLibraryException):
 
 class TimeZoneInvalid(KeepassLibraryException):
     pass
+
+
+class RobotFrameworkVersionError(KeepassLibraryException):
+    pass

--- a/src/KeePassLibrary/keywords/keepassentry.py
+++ b/src/KeePassLibrary/keywords/keepassentry.py
@@ -1,7 +1,14 @@
 """Library components."""
 from KeePassLibrary.base import keyword, LibraryComponent, Entry, datetime
-from KeePassLibrary.errors import EntryInvalid, AttachmentInvalid
+from KeePassLibrary.errors import EntryInvalid, AttachmentInvalid, RobotFrameworkVersionError
 from KeePassLibrary.utils import prepare_set_timezone, convert_datetime_timezone
+import robot
+try:
+    from robot.api.types import Secret
+    ROBOT_FRAMEWORK_HAS_SECRET = True
+except ImportError:
+    ROBOT_FRAMEWORK_HAS_SECRET = False
+    Secret = None
 
 
 class KeePassEntry(LibraryComponent):
@@ -72,19 +79,74 @@ class KeePassEntry(LibraryComponent):
 
     # ---------- Password ----------
     @keyword
-    def get_entry_password(self, entry: Entry):
+    def get_entry_password(self, entry: Entry, as_secret=False):
         """Return the password value of the supplied KeePass ``entry``.
+
+        The ``as_secret`` argument can be set to ``True`` to return the password as a Robot Framework 
+        Secret type (available in Robot Framework 7.4 and later). When ``as_secret`` is ``True`` 
+        but Robot Framework version is less than 7.4, this keyword will fail.
+
+        Parameters:
+        - ``entry``: A valid KeePass entry
+        - ``as_secret``: If ``True``, returns password as Secret type (requires RF 7.4+). Default: ``False``
 
         Example:
         | ${entry} = | `Get Entries By Title` | root_entry | first=True |
         | ${value} = | `Get Entry Password`   | ${entry}                |
 
+        Example with Secret type (Robot Framework 7.4+):
+        | ${entry} = | `Get Entries By Title` | root_entry | first=True      |
+        | ${secret} = | `Get Entry Password`  | ${entry}   | as_secret=True |
+
         New in KeePassLibrary 0.3
+        Updated in KeePassLibrary 0.11 to support Secret type
         """
         if isinstance(entry, Entry):
-            return entry.password
+            password = entry.password
+            
+            if as_secret:
+                # Check if Robot Framework supports Secret type
+                if not self._is_secret_supported():
+                    rf_version = self._get_robot_framework_version()
+                    raise RobotFrameworkVersionError(
+                        f"Secret type is not available in Robot Framework {rf_version}. "
+                        "Secret type requires Robot Framework 7.4 or later."
+                    )
+                return Secret(password)
+            else:
+                return password
         else:
             raise EntryInvalid('Invalid KeePass Entry.')
+
+    def _is_secret_supported(self):
+        """Check if the current Robot Framework version supports Secret type."""
+        if not ROBOT_FRAMEWORK_HAS_SECRET:
+            return False
+        
+        # Additional version check if needed
+        rf_version = self._get_robot_framework_version()
+        if rf_version == "unknown":
+            return False
+            
+        try:
+            # Parse version string to compare with 7.4
+            version_parts = rf_version.split('.')
+            major = int(version_parts[0])
+            minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+            
+            # Check if version is 7.4 or higher
+            return (major > 7) or (major == 7 and minor >= 4)
+        except (ValueError, IndexError):
+            # If we can't parse the version, fall back to import check
+            return ROBOT_FRAMEWORK_HAS_SECRET
+
+    def _get_robot_framework_version(self):
+        """Get the current Robot Framework version."""
+        try:
+            import robot
+            return robot.__version__
+        except AttributeError:
+            return "unknown"
 
     @keyword
     def set_entry_password(self, entry: Entry, value):

--- a/utests/test/test_secret_functionality.py
+++ b/utests/test/test_secret_functionality.py
@@ -1,0 +1,123 @@
+"""Unit tests for the Secret type functionality in KeePassEntry."""
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add the src directory to the path to import the modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+try:
+    from KeePassLibrary.keywords.keepassentry import KeePassEntry
+    from KeePassLibrary.errors import RobotFrameworkVersionError, EntryInvalid
+except ImportError as e:
+    print(f"Failed to import modules: {e}")
+    print("Make sure the src directory is accessible")
+    raise
+
+
+class TestKeePassEntrySecret(unittest.TestCase):
+    """Test cases for the Secret type functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a mock context for KeePassEntry
+        mock_ctx = MagicMock()
+        self.keepass_entry = KeePassEntry(mock_ctx)
+        
+        # Create a mock entry
+        self.mock_entry = MagicMock()
+        self.mock_entry.password = "test_password"
+
+    def test_get_entry_password_default_behavior(self):
+        """Test that default behavior returns plain password."""
+        result = self.keepass_entry.get_entry_password(self.mock_entry)
+        self.assertEqual(result, "test_password")
+
+    def test_get_entry_password_as_secret_false(self):
+        """Test that as_secret=False returns plain password."""
+        result = self.keepass_entry.get_entry_password(self.mock_entry, as_secret=False)
+        self.assertEqual(result, "test_password")
+
+    def test_get_entry_password_invalid_entry(self):
+        """Test that invalid entry raises EntryInvalid."""
+        with self.assertRaises(EntryInvalid):
+            # Pass an object that's not an Entry instance  
+            invalid_entry = MagicMock()
+            # Make isinstance return False for this mock
+            with patch('builtins.isinstance', return_value=False):
+                self.keepass_entry.get_entry_password(invalid_entry)
+
+    @patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', False)
+    def test_get_entry_password_as_secret_unsupported(self):
+        """Test that as_secret=True raises error when Secret is not supported."""
+        with patch.object(self.keepass_entry, '_get_robot_framework_version', return_value='6.1.1'):
+            with self.assertRaises(RobotFrameworkVersionError) as context:
+                self.keepass_entry.get_entry_password(self.mock_entry, as_secret=True)
+            
+            self.assertIn("Secret type is not available", str(context.exception))
+            self.assertIn("Robot Framework 6.1.1", str(context.exception))
+
+    @patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', True)
+    @patch('KeePassLibrary.keywords.keepassentry.Secret')
+    def test_get_entry_password_as_secret_supported(self, mock_secret):
+        """Test that as_secret=True works when Secret is supported."""
+        # Mock version check to return True
+        with patch.object(self.keepass_entry, '_is_secret_supported', return_value=True):
+            mock_secret_instance = MagicMock()
+            mock_secret.return_value = mock_secret_instance
+            
+            result = self.keepass_entry.get_entry_password(self.mock_entry, as_secret=True)
+            
+            mock_secret.assert_called_once_with("test_password")
+            self.assertEqual(result, mock_secret_instance)
+
+    def test_is_secret_supported_version_74(self):
+        """Test version check for Robot Framework 7.4."""
+        with patch.object(self.keepass_entry, '_get_robot_framework_version', return_value='7.4.0'):
+            with patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', True):
+                result = self.keepass_entry._is_secret_supported()
+                self.assertTrue(result)
+
+    def test_is_secret_supported_version_75(self):
+        """Test version check for Robot Framework 7.5."""
+        with patch.object(self.keepass_entry, '_get_robot_framework_version', return_value='7.5.0'):
+            with patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', True):
+                result = self.keepass_entry._is_secret_supported()
+                self.assertTrue(result)
+
+    def test_is_secret_supported_version_73(self):
+        """Test version check for Robot Framework 7.3 (should fail)."""
+        with patch.object(self.keepass_entry, '_get_robot_framework_version', return_value='7.3.0'):
+            with patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', True):
+                result = self.keepass_entry._is_secret_supported()
+                self.assertFalse(result)
+
+    def test_is_secret_supported_version_80(self):
+        """Test version check for Robot Framework 8.0."""
+        with patch.object(self.keepass_entry, '_get_robot_framework_version', return_value='8.0.0'):
+            with patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', True):
+                result = self.keepass_entry._is_secret_supported()
+                self.assertTrue(result)
+
+    def test_is_secret_supported_no_import(self):
+        """Test version check when Secret import fails."""
+        with patch('KeePassLibrary.keywords.keepassentry.ROBOT_FRAMEWORK_HAS_SECRET', False):
+            result = self.keepass_entry._is_secret_supported()
+            self.assertFalse(result)
+
+    def test_get_robot_framework_version(self):
+        """Test getting Robot Framework version."""
+        with patch('robot.__version__', '7.4.0'):
+            result = self.keepass_entry._get_robot_framework_version()
+            self.assertEqual(result, '7.4.0')
+
+    def test_get_robot_framework_version_no_attribute(self):
+        """Test getting Robot Framework version when __version__ is not available."""
+        with patch('robot.__version__', side_effect=AttributeError):
+            result = self.keepass_entry._get_robot_framework_version()
+            self.assertEqual(result, 'unknown')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently, security is compromised because the secret that is read out is logged in plain text when it is assigned to a variable:

<img width="944" height="153" alt="CleanShot2025-10-08_07-57-26" src="https://github.com/user-attachments/assets/3cc28d7f-e181-4b4d-afbf-1052add5bc20" />

To prevent this, you would have to use some tricks (listeners, etc.).

This PR enhances the `Get Entry Password` keyword by adding support for returning the password as a [Secret type, introduced in Robot Framework 7.4](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-7.4b1.rst#id24).

A new argument `as_secret` has been added to the keyword control this behavior.

When enabled, the password is returned as type "Secret", preventing it from being logged in plain text and improving security when handling sensitive data.
 
**Example**: 

<img width="828" height="315" alt="CleanShot2025-10-08_09-04-33" src="https://github.com/user-attachments/assets/bc59eb8a-762c-47c7-92b8-44c73d72c30c" />

Use with BrowserLibrary: 

<img width="921" height="128" alt="CleanShot2025-10-08_09-10-00" src="https://github.com/user-attachments/assets/c75e8237-4fd4-4998-bbfe-ca29790e327c" />
